### PR TITLE
Chore - add correct beacon refresh failed logging

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1006,7 +1006,7 @@ def refresh_beacons():
     try:
         ret = __salt__['event.fire']({}, 'beacons_refresh')
     except KeyError:
-        log.error('Event module not available. Module refresh failed.')
+        log.error('Event module not available. Beacon refresh failed.')
         ret = False  # Effectively a no-op, since we can't really return without an event system
     return ret
 


### PR DESCRIPTION
### What does this PR do?
Adds the correct error logging message if a beacon fails.
Currently `refresh_modules` and `refresh_beacons` have the same error output upon failure.

refresh_modules:
https://github.com/saltstack/salt/blob/073c4f3e350184db99feaa37a32868378cdf6e82/salt/modules/saltutil.py#L1097

refresh_beacons:
https://github.com/saltstack/salt/blob/073c4f3e350184db99feaa37a32868378cdf6e82/salt/modules/saltutil.py#L1009

### What issues does this PR fix or reference?
No issue reported

### Previous Behavior
Module refresh and beacon refresh would throw the same error upon failure.

### New Behavior
Beacon refresh now has the correct failure thrown to match pillars, matchers, etc

### Tests written?
No

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
