### PR TITLE
Add master_return_strategy feature

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -280,6 +280,28 @@ to the next master in the list if it finds the existing one is dead.
 
     master_alive_interval: 30
 
+.. conf_minion:: master_return_strategy
+
+``master_return_strategy``
+--------------------------
+
+.. versionadded:: 2018.x.x
+
+Default: ``source``
+
+This option controls the master return strategy. Can be ``source`` or ``any``.
+If set to ``source``, then the minion will only attempt to return the job
+results to the master that sent the job. If set to ``any``, then the minion
+will attempt to return the job results to the master that sent the job but if
+that fails, then the minion will attempt to return the job results to the next
+connected master in the configuration. :conf_minion:`master_alive_interval`
+must also be set. This is used to keep track of which masters are currently
+connected.
+
+.. code_block:: yaml
+
+    master_return_strategy: source
+
 .. conf_minion:: master_shuffle
 
 ``master_shuffle``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -141,6 +141,9 @@ VALID_OPTS = immutabletypes.freeze({
     # is interrupted and try another master in the list.
     'master_alive_interval': int,
 
+    # The strategy to use when returning results back to the master.
+    'master_return_strategy': six.string_types,
+
     # When in multi-master failover mode, fail back to the first master in the list if it's back
     # online.
     'master_failback': bool,
@@ -1227,6 +1230,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze({
     'master_finger': '',
     'master_shuffle': False,
     'master_alive_interval': 0,
+    'master_return_strategy': 'source',
     'master_failback': False,
     'master_failback_interval': 0,
     'verify_master_pubkey_sign': False,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -974,7 +974,19 @@ class MinionManager(MinionBase):
 
     @tornado.gen.coroutine
     def handle_event(self, package):
-        yield [minion.handle_event(package) for minion in self.minions]
+        tag, data = salt.utils.event.SaltEvent.unpack(package)
+        if tag == 'master_return':
+            connected_minions = [minion for minion in self.minions if minion.connected]
+            master_return_strategy = self.opts['master_return_strategy']
+
+            # send to the 1st connected minion
+            if connected_minions and master_return_strategy == 'any':
+                minion = connected_minions[0]
+                yield minion.handle_event(package)
+            else:
+                raise tornado.gen.Return()
+        else:
+            yield [minion.handle_event(package) for minion in self.minions]
 
     def _create_minion_object(self, opts, timeout, safe,
                               io_loop=None, loaded_base_name=None,
@@ -2042,7 +2054,15 @@ class Minion(MinionBase):
                 ret_val = self._send_req_sync(load, timeout=timeout)
             except SaltReqTimeoutError:
                 timeout_handler()
-                return ''
+                if self.opts['master_return_strategy'] == 'any':
+                    log.info(
+                        'Attempting to return the job information for '
+                        'job %s to another master.', jid
+                    )
+                    evt = salt.utils.event.get_event('minion', opts=self.opts, listen=False)
+                    ret_val = evt.fire_event(load, tag='master_return')
+                else:
+                    return ''
         else:
             with tornado.stack_context.ExceptionStackContext(timeout_handler):
                 ret_val = self._send_req_async(load, timeout=timeout, callback=lambda f: None)  # pylint: disable=unexpected-keyword-arg
@@ -2457,6 +2477,14 @@ class Minion(MinionBase):
             log.debug('Forwarding master event tag=%s', data['tag'])
             self._fire_master(data['data'], data['tag'], data['events'], data['pretag'])
 
+    def _handle_tag_master_return(self, tag, data):
+        '''
+        Handle a master_return event
+        '''
+        log.debug('Returning results for jid=%s to %s', data.get('jid'), self.opts['master'])
+        self._return_pub(data)
+
+    @tornado.gen.coroutine
     def _handle_tag_master_disconnected_failback(self, tag, data):
         '''
         Handle a master_disconnected_failback event
@@ -2573,6 +2601,7 @@ class Minion(MinionBase):
                     self.restart = True
                     self.io_loop.stop()
 
+    @tornado.gen.coroutine
     def _handle_tag_master_connected(self, tag, data):
         '''
         Handle a master_connected event
@@ -2661,6 +2690,7 @@ class Minion(MinionBase):
                          'salt/auth/creds': self._handle_tag_salt_auth_creds,
                          '_salt_error': self._handle_tag_salt_error,
                          '__schedule_return': self._handle_tag_schedule_return,
+                         'master_return': self._handle_tag_master_return,
                          master_event(type='disconnected'): self._handle_tag_master_disconnected_failback,
                          master_event(type='failback'): self._handle_tag_master_disconnected_failback,
                          master_event(type='connected'): self._handle_tag_master_connected,


### PR DESCRIPTION
### What does this PR do?

If the `master_type` is set to `str`, then this option controls the master return strategy. Can be `source` or `any`. If set to `source`, then the minion will only attempt to return the job results to the master that sent the job. If set to `any`, then the minion will attempt to return the job results to the master that sent the job but if that fails, then the minion will attempt to return the job results to the other masters until successful or the master list has been exhausted. `master_alive_interval` must also be set. This is used to keep track of which masters are currently connected.

### What issues does this PR fix or reference?

https://jira5.prod.bloomberg.com/browse/RDTISALT-2569

### Previous Behavior

If a master sends a job to a minion and then goes down before receiving the job return, then that data is lost to the master(s) forever.

### New Behavior

If the source master goes down before receiving the job return then try to send the return to the other connected masters.

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
